### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyTerrier_t5
 
-This is the [PyTerrier](https://github.com/terrier-org/pyterrier) plugin for the [Mono and Duo T5](https://arxiv.org/pdf/2101.05667.pdf) ranking approaches [Nogueira21].
+This is the [PyTerrier](https://github.com/terrier-org/pyterrier) plugin for the [Mono and Duo T5](https://arxiv.org/pdf/2101.05667.pdf) ranking approaches [[Nogueira21]](#Nogueira21).
 
 Note that this package only supports scoring from a pretrained models (like [this one](https://huggingface.co/castorini/monot5-base-msmarco)).
 
@@ -53,8 +53,8 @@ into passages and aggregating the results ([examples](https://pyterrier.readthed
 
 ## References
 
-  - [Nogueira21]: Ronak Pradeep, Rodrigo Nogueira, and Jimmy Lin. The Expando-Mono-Duo Design Pattern for Text Ranking withPretrained Sequence-to-Sequence Models. https://arxiv.org/pdf/2101.05667.pdf
-  - [Macdonald20]: Craig Macdonald, Nicola Tonellotto. Declarative Experimentation inInformation Retrieval using PyTerrier. Craig Macdonald and Nicola Tonellotto. In Proceedings of ICTIR 2020. https://arxiv.org/abs/2007.14271
+  - <a id="Nogueira21"/>Ronak Pradeep, Rodrigo Nogueira, and Jimmy Lin. The Expando-Mono-Duo Design Pattern for Text Ranking withPretrained Sequence-to-Sequence Models. https://arxiv.org/pdf/2101.05667.pdf
+  - <a id="Macdonald20"/>Craig Macdonald, Nicola Tonellotto. Declarative Experimentation inInformation Retrieval using PyTerrier. Craig Macdonald and Nicola Tonellotto. In Proceedings of ICTIR 2020. https://arxiv.org/abs/2007.14271
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ You can use MonoT5 just like any other text-based re-ranker. By default, it uses
 trained on MS MARCO passage ranking training queries.
 
 ```python
-from pyterrier_t5 import MonoT5ReRanker
+import pyterrier as pt
+from pyterrier_t5 import MonoT5ReRanker, DuoT5ReRanker
 monoT5 = MonoT5ReRanker() # loads castorini/monot5-base-msmarco by default
 duoT5 = DuoT5ReRanker() # loads castorini/duot5-base-msmarco by default
 


### PR DESCRIPTION
Fixed some imports, so that code examples can be copy-pasted.
And the reference to the paper is now cross-linked.