### PR TITLE
Fix for sequences of unequal length

### DIFF
--- a/pyterrier_t5/__init__.py
+++ b/pyterrier_t5/__init__.py
@@ -29,7 +29,7 @@ class MonoT5ReRanker(pt.Transformer):
         self.verbose = verbose
         self.batch_size = batch_size
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        self.tokenizer = T5Tokenizer.from_pretrained(tok_model)
+        self.tokenizer = T5Tokenizer.from_pretrained(tok_model, padding_side="left")
         self.model_name = model
         self.model = T5ForConditionalGeneration.from_pretrained(model)
         self.model.to(self.device)
@@ -84,7 +84,7 @@ class DuoT5ReRanker(pt.Transformer):
         self.verbose = verbose
         self.batch_size = batch_size
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        self.tokenizer = T5Tokenizer.from_pretrained(tok_model)
+        self.tokenizer = T5Tokenizer.from_pretrained(tok_model, padding_side="left")
         self.model_name = model
         self.model = T5ForConditionalGeneration.from_pretrained(model)
         self.model.to(self.device)
@@ -184,7 +184,7 @@ class mT5ReRanker(pt.Transformer):
         self.verbose = verbose
         self.batch_size = batch_size
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        self.tokenizer = T5Tokenizer.from_pretrained(tok_model)
+        self.tokenizer = T5Tokenizer.from_pretrained(tok_model, padding_side="left")
         self.model_name = model
         self.model = MT5ForConditionalGeneration.from_pretrained(model)
         self.model.to(self.device)


### PR DESCRIPTION
The tokenizer uses right-side padding by default. Since the prompt is concatenated to the input ids, this becomes a problem when unequal input lengths are passed through in a single batch. For example, for the following two input sequences, the padding tokens of the first input sequence are retained.

```
Query: foo Document: bar Relevant:
Query: foo Document: bar bar bar bar bar bar bar bar Relevant:
```

The first sequence gets tokenized into:
```
['▁', 'Query', ':', '▁fo', 'o', '▁Document', ':', '▁bar', '</s>', '<pad>', '<pad>', '<pad>', '<pad>', '<pad>', '<pad>', '▁Relevan', 't', ':', '</s>']
```


Setting the padding side to left circumvents this issue