### PR TITLE
Add instructions to reproduce Light-MonoT5

### DIFF
--- a/training/monot5/README.md
+++ b/training/monot5/README.md
@@ -6,6 +6,67 @@ Here we provide code we have used for training monoT5 models.
 
  - t5-train-bm25negs.py - this uses the MSMARCO training queries for training monoT5. It adds negative samples obtained using BM25 from a Pisa index.
 
+## Reproducibility of monoT5
+
+To replicate the performance of monoT5 base on MSMARCO from the original monoT5 paper [1], you should use t5train.py with the following configuration: 
+
+- train the model for one epoch on the small set of [MSMARCO-passage triples](https://huggingface.co/datasets/irds/msmarco-passage_train_triples-small)
+- Since Nogueira et al. [1] limited the number of triples to 6.4e-5, number_df = 640000, which corresponds to 10k steps
+- Use Adafactor as optimizer, with learning rate equal to 3e-4 and weigth decay equal to 5e-5
+- Use batch size equal to 128 by applying gradient accumulation (mini batch size = 8, number of accumulation = 16)
+- Truncate the input sentence with 'longest_first' option and max_length = 512
+
+In this way, you can reproduce [monoT5-base-10k](https://huggingface.co/castorini/monot5-base-msmarco-10k) with the following results:
+
+|  **Model** | **AP** | **RR** | **nDCG@10** |
+|:----------:|:------:|:------:|:-----------:|
+| MonoT5 [1] | 0.368  |  0.947 |    0.699    |
+| Replicated | 0.367  |  0.944 |    0.700    |
+
+
+## How to reproduce Light-MonoT5
+
+To replicate the performance of Light-MonoT5 base [2] on MSMARCO, you should use t5train.py with the same configuration as MonoT5 but with two differences: 
+
+- Put number_df = 6400000, in this way we can compare with [monot5-base-100k](https://huggingface.co/castorini/monot5-base-msmarco), which has been trained for 100k steps (and not 10k)
+- The only parameters updated during the training are the embeddings of the prompt tokens, i.e. `Query`, `Document`, `Relevant`, `true`, `false`, `EoS` (`End of Sentence` token) and `Colon` (`:`). You need to add the following code to t5train.py:
+
+````
+# Register hook to zero out gradients for all tokens not in the prompt
+def mask_gradients(grad):
+    mask = torch.zeros_like(grad)
+    # If you want to train the token Query
+    mask[27569] = 1.0
+    mask[3] = 1.0
+    # If you want to train the token Document
+    mask[11167] = 1.0
+    # If you want to train the token Relevant
+    mask[31484] = 1.0
+    # If you want to train the tokens true and false
+    mask[1176] = 1.0
+    mask[6136] = 1.0
+    # If you want to train the EoS token
+    mask[1] = 1.0
+    # If you want to train the Colon (:)
+    mask[10] = 1.0
+    
+    return grad * mask
+
+embedding_weight = model.get_input_embeddings().weight
+embedding_weight.requires_grad = True
+embedding_weight.register_hook(mask_gradients)
+````
+
+All the other parameters of the model must have `requires_grad = False`.
+
+# References
+
+[1] [NOGUEIRA, Rodrigo, et al. Document Ranking with a Pretrained Sequence-to-Sequence Model. In: EMNLP 2020](https://aclanthology.org/2020.findings-emnlp.63/)
+
+[2] Braga et al., 'Revealing MonoT5’s Learning Mechanisms via Prompt-Token Adaptation' in ECIR 2026
+
 # Credits
 
 Sean MacAvaney, University of Glasgow
+
+Marco Braga, University of Milano-Bicocca

--- a/training/monot5/README.md
+++ b/training/monot5/README.md
@@ -8,13 +8,11 @@ Here we provide code we have used for training monoT5 models.
 
 ## Reproducibility of monoT5
 
-To replicate the performance of monoT5 base on MSMARCO from the original monoT5 paper [1], you should use t5train.py with the following configuration: 
+To replicate the performance of monoT5 base on MSMARCO from the original monoT5 paper [1], you should use t5train.py with the following command:
 
-- train the model for one epoch on the small set of [MSMARCO-passage triples](https://huggingface.co/datasets/irds/msmarco-passage_train_triples-small)
-- Since Nogueira et al. [1] limited the number of triples to 6.4e-5, number_df = 640000, which corresponds to 10k steps
-- Use Adafactor as optimizer, with learning rate equal to 3e-4 and weigth decay equal to 5e-5
-- Use batch size equal to 128 by applying gradient accumulation (mini batch size = 8, number of accumulation = 16)
-- Truncate the input sentence with 'longest_first' option and max_length = 512
+````
+python t5train.py --train_type 'full' --steps 1
+````
 
 In this way, you can reproduce [monoT5-base-10k](https://huggingface.co/castorini/monot5-base-msmarco-10k) with the following results:
 
@@ -26,38 +24,11 @@ In this way, you can reproduce [monoT5-base-10k](https://huggingface.co/castorin
 
 ## How to reproduce Light-MonoT5
 
-To replicate the performance of Light-MonoT5 base [2] on MSMARCO, you should use t5train.py with the same configuration as MonoT5 but with two differences: 
-
-- Put number_df = 6400000, in this way we can compare with [monot5-base-100k](https://huggingface.co/castorini/monot5-base-msmarco), which has been trained for 100k steps (and not 10k)
-- The only parameters updated during the training are the embeddings of the prompt tokens, i.e. `Query`, `Document`, `Relevant`, `true`, `false`, `EoS` (`End of Sentence` token) and `Colon` (`:`). You need to add the following code to t5train.py:
+To replicate the performance of Light-MonoT5 base [2] on MSMARCO, you should use t5train.py with the following configuration: 
 
 ````
-# Register hook to zero out gradients for all tokens not in the prompt
-def mask_gradients(grad):
-    mask = torch.zeros_like(grad)
-    # If you want to train the token Query
-    mask[27569] = 1.0
-    mask[3] = 1.0
-    # If you want to train the token Document
-    mask[11167] = 1.0
-    # If you want to train the token Relevant
-    mask[31484] = 1.0
-    # If you want to train the tokens true and false
-    mask[1176] = 1.0
-    mask[6136] = 1.0
-    # If you want to train the EoS token
-    mask[1] = 1.0
-    # If you want to train the Colon (:)
-    mask[10] = 1.0
-    
-    return grad * mask
-
-embedding_weight = model.get_input_embeddings().weight
-embedding_weight.requires_grad = True
-embedding_weight.register_hook(mask_gradients)
+python t5train.py --train_type 'light' --steps 10
 ````
-
-All the other parameters of the model must have `requires_grad = False`.
 
 # References
 

--- a/training/monot5/t5train.py
+++ b/training/monot5/t5train.py
@@ -15,7 +15,7 @@ BATCH_SIZE = 8
 import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('--train_type', type=str, choices=['full', 'light'], default='full', help='Training strategy to use: Full-tuning or Light-MonoT5')
-parser.add_argument('--steps', type=str, choices=['1', '10'], default='10', help='Number of training steps')
+parser.add_argument('--steps', type=int, choices=[1, 10], default=10, help='Number of training steps')
 parser.add_argument('--epochs', type=str, default='1', help='Number of epochs')
 
 import torch

--- a/training/monot5/t5train.py
+++ b/training/monot5/t5train.py
@@ -6,20 +6,27 @@ pt.init()
 from pyterrier.measures import *
 from pyterrier_t5 import MonoT5ReRanker
 from transformers import T5ForConditionalGeneration, T5Tokenizer
-from transformers import AdamW
+from torch.optim import AdamW, Adafactor
 from random import Random
 import itertools
 
-BATCH_SIZE = 16
+BATCH_SIZE = 8
+
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument('--train_type', type=str, choices=['full', 'light'], default='full', help='Training strategy to use: Full-tuning or Light-MonoT5')
+parser.add_argument('--steps', type=str, choices=['1', '10'], default='10', help='Number of training steps')
+parser.add_argument('--epochs', type=str, default='1', help='Number of epochs')
 
 import torch
-torch.manual_seed(0)
+torch.manual_seed(123)
 
 _logger = ir_datasets.log.easy()
 
 OUTPUTS = ['true', 'false']
 
 def iter_train_samples():
+  dataset_triple = load_dataset('irds/msmarco-passage_train_triples-small', 'docpairs', trust_remote_code=True)
   dataset = ir_datasets.load('msmarco-passage/train')
   docs = dataset.docs_store()
   queries = {q.query_id: q.text for q in dataset.queries_iter()}
@@ -32,7 +39,42 @@ train_iter = _logger.pbar(iter_train_samples(), desc='total train samples')
 
 model = T5ForConditionalGeneration.from_pretrained("t5-base").cuda()
 tokenizer = T5Tokenizer.from_pretrained("t5-base")
-optimizer = AdamW(model.parameters(), lr=5e-5)
+
+if args.train_type=='full':
+  # We require the training of all the parameters in the model 
+  for param in model.parameters():
+    param.requires_grad = True
+
+if args.train_type=='light':
+  # We need to update only the parameters related to the prompt tokens
+  
+  def mask_gradients(grad):
+    mask = torch.zeros_like(grad)
+    # Here we train the embedding of token 'Query'
+    mask[27569] = 1.0
+    mask[3] = 1.0
+    # Here token 'Document'
+    mask[11167] = 1.0
+    # Here token 'Relevant'
+    mask[31484] = 1.0
+    # Here 'true' and 'false'
+    mask[1176] = 1.0
+    mask[6136] = 1.0
+    # Here the 'End of Sentence' (EoS) token
+    mask[1] = 1.0
+    # Here the Colon token (:)
+    mask[10] = 1.0
+    
+    return grad * mask
+
+  # We update only a subset of the embedding layer
+  # All the other parameters remain frozen
+  embedding_weight = model.get_input_embeddings().weight
+  embedding_weight.requires_grad = True
+  embedding_weight.register_hook(mask_gradients)
+
+
+optimizer = Adafactor(model.parameters(), lr=3e-4, weight_decay=5e-5)
 
 
 reranker = MonoT5ReRanker(verbose=False, batch_size=BATCH_SIZE)
@@ -52,16 +94,21 @@ def build_validation_data():
 valid_data = build_validation_data()
 valid_qrels = pt.get_dataset('irds:msmarco-passage/trec-dl-2019/judged').get_qrels()
 
-epoch = 0
+epochs = args.epochs
 
 max_ndcg = 0.
 
-while True:
-  with _logger.pbar_raw(desc=f'train {epoch}', total=16384 // BATCH_SIZE) as pbar:
+# We limit the number of triple, i.e. number_df
+
+number_df = 640000*args.steps
+
+for epoch in range(epochs): 
+
+  with _logger.pbar_raw(desc=f'train {epoch}', total=number_df // BATCH_SIZE) as pbar:
     model.train()
     total_loss = 0
     count = 0
-    for _ in range(16384 // BATCH_SIZE):
+    for k in range(number_df // BATCH_SIZE):
       inp, out = [], []
       for i in range(BATCH_SIZE):
         i, o = next(train_iter)
@@ -71,12 +118,17 @@ while True:
       out_ids = tokenizer(out, return_tensors='pt', padding=True).input_ids.cuda()
       loss = model(input_ids=inp_ids, labels=out_ids).loss
       loss.backward()
-      optimizer.step()
-      optimizer.zero_grad()
+      # Gradient accumulation (mini batch size = 8, number of accumulation = 16)
+      if (k + 1) % 16 == 0:
+          optimizer.step()
+          optimizer.zero_grad()
       total_loss = loss.item()
       count += 1
       pbar.update(1)
       pbar.set_postfix({'loss': total_loss/count})
+
+  # Evaluation on TREC DL 19
+  
   with _logger.duration(f'valid {epoch}'):
     reranker.model = model
     reranker.verbose = True
@@ -91,4 +143,4 @@ while True:
       _logger.info('new best nDCG')
       model.save_pretrained(f'./mymodel-best-{epoch}')
       max_ndcg = metrics['nDCG']
-  epoch += 1
+  


### PR DESCRIPTION
I updated the README with the hyperparameters to reproduce the training of MonoT5 on MS MARCO and with the instructions for training Light-MonoT5 (ECIR 2026) on MS MARCO